### PR TITLE
allow for service names with spaces in

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -275,6 +275,15 @@ func LocalServerIP() (string, error) {
 	return localIP, nil
 }
 
+func CallBackAddress() (string, error) {
+	callback := viper.GetString("hyperclair.callback")
+	if callback != "" {
+		return callback, nil
+	} else {
+		return LocalServerIP()
+	}
+}
+
 func translateInterface(localInterface string) (string, error) {
 	logrus.Debugf("selected interface: %v", localInterface)
 

--- a/docker/push.go
+++ b/docker/push.go
@@ -21,7 +21,7 @@ func Push(image Image) error {
 	if layerCount == 0 {
 		logrus.Warningln("there is no layer to push")
 	}
-	localIP, err := config.LocalServerIP()
+	localIP, err := config.CallBackAddress()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR allows hyperclair to authenticate when the www-authenticate header's service field has a space or other special character in it.
