### PR TITLE
Add https support for private docker registries and support Basic realm

### DIFF
--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -32,7 +32,7 @@ var analyseCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		ia := analyse(args[0])
+		ia := analyse(args[0], insecureRegistry)
 
 		err := template.Must(template.New("analysis").Parse(analyseTplt)).Execute(os.Stdout, ia)
 		if err != nil {
@@ -42,12 +42,12 @@ var analyseCmd = &cobra.Command{
 	},
 }
 
-func analyse(imageName string) clair.ImageAnalysis {
+func analyse(imageName string, insecure bool) clair.ImageAnalysis {
 	var err error
 	var image docker.Image
 
 	if !docker.IsLocal {
-		image, err = docker.Pull(imageName)
+		image, err = docker.Pull(imageName, insecure)
 
 		if err != nil {
 			if err == xerrors.NotFound {
@@ -59,7 +59,7 @@ func analyse(imageName string) clair.ImageAnalysis {
 		}
 
 	} else {
-		image, err = docker.Parse(imageName)
+		image, err = docker.Parse(imageName, insecureRegistry)
 		if err != nil {
 			fmt.Println(xerrors.InternalError)
 			logrus.Fatalf("parsing local image %q: %v", imageName, err)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -27,8 +27,12 @@ var loginCmd = &cobra.Command{
 
 		var reg string = docker.DockerHub
 
+		// We are setting http/https scheme depending on insecure registry
+		// For docker hub always https
 		if len(args) == 1 {
-			reg = args[0]
+			reg = fmtRegistryURI(args[0], insecureRegistry)
+		} else {
+			reg = fmtRegistryURI(reg, false)
 		}
 
 		var login config.Login

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -44,7 +44,7 @@ var pullCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		im := args[0]
-		image, err := docker.Pull(im)
+		image, err := docker.Pull(im, insecureRegistry)
 		if err != nil {
 			fmt.Println(xerrors.ServiceUnavailable)
 			logrus.Fatalf("pulling image %v: %v", args[0], err)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -30,7 +30,7 @@ var pushCmd = &cobra.Command{
 		var image docker.Image
 		if !docker.IsLocal {
 			var err error
-			image, err = docker.Pull(imageName)
+			image, err = docker.Pull(imageName, insecureRegistry)
 			if err != nil {
 				if err == xerrors.NotFound {
 					fmt.Println(err)
@@ -41,7 +41,8 @@ var pushCmd = &cobra.Command{
 			}
 		} else {
 			var err error
-			image, err = docker.Parse(imageName)
+
+			image, err = docker.Parse(imageName, insecureRegistry)
 			if err != nil {
 				fmt.Println(xerrors.InternalError)
 				logrus.Fatalf("parsing local image %q: %v", imageName, err)

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -24,7 +24,7 @@ var reportCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		analyses := analyse(args[0])
+		analyses := analyse(args[0], insecureRegistry)
 		imageName := strings.Replace(analyses.ImageName, "/", "-", -1) + "-" + analyses.Tag
 		switch clair.Report.Format {
 		case "html":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wemanity-belgium/hyperclair/config"
@@ -24,6 +25,22 @@ import (
 
 var cfgFile string
 var logLevel string
+
+// Format Docker Registry URL
+func fmtRegistryURI(u string, insecure bool) (uri string) {
+	uri = u
+	if !strings.HasPrefix(uri, "http://") && !strings.HasPrefix(uri, "https://") {
+		if insecure {
+			uri = "http://" + uri
+		} else {
+			uri = "https://" + uri
+		}
+	}
+	return uri
+}
+
+// Insecure registry var
+var insecureRegistry bool
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -49,6 +66,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.hyperclair.yml)")
 	RootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level [Panic,Fatal,Error,Warn,Info,Debug]")
+	RootCmd.PersistentFlags().BoolVar(&insecureRegistry, "insecure-registry", false, "Use http instead of https if supplied")
 }
 
 func initConfig() {

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -67,7 +67,7 @@ func AuthenticateResponse(dockerResponse *http.Response, request *http.Request) 
 		return err
 	}
 
-	l, err := config.GetLogin(strings.Trim(bearerToken["realm"], "/"))
+	l, err := config.GetLogin(fmt.Sprintf("%s://%s", request.URL.Scheme, request.URL.Host))
 	if err != nil {
 		return err
 	}

--- a/docker/auth.go
+++ b/docker/auth.go
@@ -1,12 +1,15 @@
 package docker
 
 import (
+	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/wemanity-belgium/hyperclair/config"
 	"github.com/wemanity-belgium/hyperclair/docker/httpclient"
 	"github.com/wemanity-belgium/hyperclair/xerrors"
@@ -23,9 +26,14 @@ func (tok token) String() string {
 //BearerAuthParams parse Bearer Token on Www-Authenticate header
 func BearerAuthParams(r *http.Response) map[string]string {
 	s := strings.Fields(r.Header.Get("Www-Authenticate"))
-	if len(s) != 2 || s[0] != "Bearer" {
+
+	// Adding Basic authentication support
+	bearer_or_basic, _ := regexp.MatchString("Bearer|Basic", s[0])
+	if len(s) != 2 || !bearer_or_basic {
+		logrus.Fatalf("Authentication Realm is not supported: ", s[0])
 		return nil
 	}
+
 	result := map[string]string{}
 
 	for _, kv := range strings.Split(s[1], ",") {
@@ -40,7 +48,16 @@ func BearerAuthParams(r *http.Response) map[string]string {
 
 func AuthenticateResponse(dockerResponse *http.Response, request *http.Request) error {
 	bearerToken := BearerAuthParams(dockerResponse)
-	url := bearerToken["realm"] + "?service=" + bearerToken["service"]
+	url := ""
+
+	s := strings.Fields(dockerResponse.Header.Get("Www-Authenticate"))
+
+	if s[0] == "Bearer" {
+		url = bearerToken["realm"] + "?service=" + bearerToken["service"]
+	} else {
+		url = bearerToken["realm"] + "v2/"
+	}
+
 	if bearerToken["scope"] != "" {
 		url += "&scope=" + bearerToken["scope"]
 	}
@@ -49,7 +66,8 @@ func AuthenticateResponse(dockerResponse *http.Response, request *http.Request) 
 	if err != nil {
 		return err
 	}
-	l, err := config.GetLogin(request.URL.Host)
+
+	l, err := config.GetLogin(strings.Trim(bearerToken["realm"], "/"))
 	if err != nil {
 		return err
 	}
@@ -76,13 +94,18 @@ func AuthenticateResponse(dockerResponse *http.Response, request *http.Request) 
 		return err
 	}
 
-	var tok token
-	err = json.Unmarshal(body, &tok)
+	if s[0] == "Bearer" {
+		var tok token
+		err = json.Unmarshal(body, &tok)
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		request.Header.Set("Authorization", "Bearer "+tok.String())
+	} else {
+		auth := fmt.Sprintf("%s:%s", l.Username, l.Password)
+		request.Header.Set("Authorization", "Basic "+b64.StdEncoding.EncodeToString([]byte(auth)))
 	}
-	request.Header.Set("Authorization", "Bearer "+tok.String())
 
 	return nil
 }

--- a/docker/image.go
+++ b/docker/image.go
@@ -46,7 +46,7 @@ func TmpLocal() string {
 //"alpine"
 //"wemanity-belgium/alpine"
 //"wemanity-belgium/alpine:latest"
-func Parse(image string) (Image, error) {
+func Parse(image string, insecure bool) (Image, error) {
 	imageRegex := regexp.MustCompile(dockerImageRegex)
 
 	if imageRegex.MatchString(image) == false {
@@ -62,15 +62,11 @@ func Parse(image string) (Image, error) {
 
 	if repository == "" && !strings.ContainsAny(registry, ":.") {
 		repository, registry = registry, hubURI //Regex problem, if no registry in url, regex parse repository as registry, so need to invert it
-
 	} else {
-		//FIXME We need to move to https. <error: tls: oversized record received with length 20527>
-		//Maybe using a `insecure-registry` flag in configuration
-		if strings.Contains(registry, "docker") {
-			registry = "https://" + registry + "/v2"
-
-		} else {
+		if insecure {
 			registry = "http://" + registry + "/v2"
+		} else {
+			registry = "https://" + registry + "/v2"
 		}
 	}
 

--- a/docker/image_test.go
+++ b/docker/image_test.go
@@ -7,32 +7,34 @@ import (
 )
 
 var imageNameTests = []struct {
-	in  string
-	out string
+	in       string
+	out      string
+	insecure bool
 }{
-	{"jgsqware/ubuntu-git", hubURI + "/jgsqware/ubuntu-git:latest"},
-	{"wemanity-belgium/registry-backup", hubURI + "/wemanity-belgium/registry-backup:latest"},
-	{"wemanity-belgium/alpine:latest", hubURI + "/wemanity-belgium/alpine:latest"},
-	{"register.com/alpine", "http://register.com/v2/alpine:latest"},
-	{"register.com/wemanity-belgium/alpine", "http://register.com/v2/wemanity-belgium/alpine:latest"},
-	{"register.com/wemanity-belgium/alpine:latest", "http://register.com/v2/wemanity-belgium/alpine:latest"},
-	{"register.com:5080/alpine", "http://register.com:5080/v2/alpine:latest"},
-	{"register.com:5080/wemanity-belgium/alpine", "http://register.com:5080/v2/wemanity-belgium/alpine:latest"},
-	{"register.com:5080/wemanity-belgium/alpine:latest", "http://register.com:5080/v2/wemanity-belgium/alpine:latest"},
-	{"registry:5000/google/cadvisor", "http://registry:5000/v2/google/cadvisor:latest"},
+	{"jgsqware/ubuntu-git", hubURI + "/jgsqware/ubuntu-git:latest", false},
+	{"wemanity-belgium/registry-backup", hubURI + "/wemanity-belgium/registry-backup:latest", false},
+	{"wemanity-belgium/alpine:latest", hubURI + "/wemanity-belgium/alpine:latest", false},
+	{"register.com/alpine", "http://register.com/v2/alpine:latest", true},
+	{"register.com/wemanity-belgium/alpine", "http://register.com/v2/wemanity-belgium/alpine:latest", true},
+	{"register.com/wemanity-belgium/alpine:latest", "http://register.com/v2/wemanity-belgium/alpine:latest", true},
+	{"register.com:5080/alpine", "http://register.com:5080/v2/alpine:latest", true},
+	{"register.com:5080/wemanity-belgium/alpine", "http://register.com:5080/v2/wemanity-belgium/alpine:latest", true},
+	{"register.com:5080/wemanity-belgium/alpine:latest", "http://register.com:5080/v2/wemanity-belgium/alpine:latest", true},
+	{"registry:5000/google/cadvisor", "http://registry:5000/v2/google/cadvisor:latest", true},
 }
 
 var invalidImageNameTests = []struct {
-	in  string
-	out string
+	in       string
+	out      string
+	insecure bool
 }{
-	{"alpine", hubURI + "/alpine:latest"},
-	{"docker.io/golang", hubURI + "/golang:latest"},
+	{"alpine", hubURI + "/alpine:latest", true},
+	{"docker.io/golang", hubURI + "/golang:latest", false},
 }
 
 func TestParse(t *testing.T) {
 	for _, imageName := range imageNameTests {
-		image, err := Parse(imageName.in)
+		image, err := Parse(imageName.in, imageName.insecure)
 		if err != nil {
 			t.Errorf("Parse(\"%s\") should be valid: %v", imageName.in, err)
 		}
@@ -45,7 +47,7 @@ func TestParse(t *testing.T) {
 
 func TestParseDisallowed(t *testing.T) {
 	for _, imageName := range invalidImageNameTests {
-		_, err := Parse(imageName.in)
+		_, err := Parse(imageName.in, imageName.insecure)
 		if err != xerrors.ErrDisallowed {
 			t.Errorf("Parse(\"%s\") should failed with err \"%v\": %v", imageName.in, xerrors.ErrDisallowed, err)
 		}
@@ -53,7 +55,7 @@ func TestParseDisallowed(t *testing.T) {
 }
 
 func TestMBlobstURI(t *testing.T) {
-	image, err := Parse("localhost:5000/alpine")
+	image, err := Parse("localhost:5000/alpine", true)
 
 	if err != nil {
 		t.Error(err)

--- a/docker/login.go
+++ b/docker/login.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/wemanity-belgium/hyperclair/docker/httpclient"
@@ -14,13 +13,6 @@ import (
 func Login(registry string) (bool, error) {
 
 	logrus.Info("log in: ", registry)
-
-	if strings.Contains(registry, "docker") {
-		registry = "https://" + registry + "/v2"
-
-	} else {
-		registry = "http://" + registry + "/v2"
-	}
 
 	client := httpclient.Get()
 	request, err := http.NewRequest("GET", registry, nil)

--- a/docker/pull.go
+++ b/docker/pull.go
@@ -12,8 +12,8 @@ import (
 )
 
 //Pull Image from Registry or Hub depending on image name
-func Pull(imageName string) (Image, error) {
-	image, err := Parse(imageName)
+func Pull(imageName string, insecure bool) (Image, error) {
+	image, err := Parse(imageName, insecure)
 	if err != nil {
 		return Image{}, err
 	}


### PR DESCRIPTION
Hi, 

I've managed to add Basic Realm authentication and `https` support for private Docker registries. Certain values were hardcoded and bound to the Docker hub, which is not usable in case the registry is private.

I would appreciate if it is possible to merge these changes and ready to make all necessary adjustments. Currently we are using forked branch to support private registry. 

Sorry no tests so far :/

Thanks
